### PR TITLE
Fix perpetual TF plan change-set for exposed_to_scripts property

### DIFF
--- a/rundeck/resource_job.go
+++ b/rundeck/resource_job.go
@@ -271,6 +271,7 @@ func resourceRundeckJob() *schema.Resource {
 						"exposed_to_scripts": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 
 						"hidden": {

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -245,6 +245,7 @@ resource "rundeck_job" "test" {
   option {
     name = "foo"
     default_value = "bar"
+    exposed_to_scripts = "false"
   }
   command {
     description = "Prints Hello World"
@@ -286,6 +287,7 @@ resource "rundeck_job" "test" {
   option {
     name = "foo"
     default_value = "bar"
+    exposed_to_scripts = "false"
   }
   command {
     job {
@@ -331,6 +333,7 @@ resource "rundeck_job" "test" {
     required = "true"
     value_choices = ["1","2","3","4","5","6","7","8","9"]
     require_predefined_choice = "true"
+    exposed_to_scripts = "false"
   }
 
   command {

--- a/rundeck/resource_job_test.go
+++ b/rundeck/resource_job_test.go
@@ -487,6 +487,7 @@ resource "rundeck_job" "test" {
   option {
     name = "foo"
     type = "file"
+    exposed_to_scripts = "false"
   }
   command {
     description = "Prints Hello World"
@@ -517,6 +518,7 @@ resource "rundeck_job" "test" {
     name = "foo"
     default_value = "bar"
     hidden = true
+    exposed_to_scripts = "false"
   }
   command {
     description = "Prints Hello World"

--- a/website/docs/r/job.html.md
+++ b/website/docs/r/job.html.md
@@ -166,7 +166,7 @@ The following arguments are supported:
   requested value is a password, private key or any other secret value.
 
 * `exposed_to_scripts`: (Optional) Boolean controlling whether the value of this option is available
-  to scripts executed by job commands. Defaults to `false`.
+  to scripts executed by job commands. Defaults to `true`.
 
 `command` blocks must have any one of the following combinations of arguments as contents:
 


### PR DESCRIPTION
## Context

Even though we are explicitly setting exposed_to_scripts for our resources every TF plan run shows a change set on rundeck jobs similar to the following:

```
~ option {
          ~ exposed_to_scripts        = false -> true
```

This makes it difficult for developers to determine what planed changes are actually happening.

Based on https://github.com/AMKamel/terraform-provider-rundeck I have patched the missing default values for exposed_to_scripts.

Local test build passes 👌 