### PR TITLE
Get Darwin arm64 build working

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg
@@ -41,7 +41,7 @@ jobs:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.13.4
+        go-version: 1.16
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Golang module download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 0.5.0 (Unreleased)
+
+## O.4.3
+* Updated Documentation
+
+## 0.4.1/0.4.2
+
+* Community improvements and updates to modern Terraform model.
+
 ## 0.4.0 (August 02, 2019)
 
 ### Added:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ build: fmt fmtcheck
 	env go install
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
+	go test $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/rundeck/go-rundeck/rundeck v0.0.0-20190510195016-2cf9670bbcc4
 )
 
-go 1.13
+go 1.16

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -155,6 +155,7 @@ github.com/hashicorp/logutils
 # github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4
 github.com/hashicorp/terraform-config-inspect/tfconfig
 # github.com/hashicorp/terraform-plugin-sdk v1.1.0
+## explicit
 github.com/hashicorp/terraform-plugin-sdk/helper/hashcode
 github.com/hashicorp/terraform-plugin-sdk/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/helper/resource
@@ -229,6 +230,7 @@ github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 github.com/posener/complete/match
 # github.com/rundeck/go-rundeck/rundeck v0.0.0-20190510195016-2cf9670bbcc4
+## explicit
 github.com/rundeck/go-rundeck/rundeck
 github.com/rundeck/go-rundeck/rundeck/auth
 # github.com/spf13/afero v1.2.2


### PR DESCRIPTION
Should hopefully fix GitHub Action goreleaser failures.

Upgrades Go to minor release 1.14 => 1.16 where Go first supported building for darwin arm64. Should really build for this since there are a few M1's around.

Merge conflict fixed